### PR TITLE
:sparkles: feat: 마감된 공고의 신청서 상태 자동 변경 기능 구현

### DIFF
--- a/src/main/java/hello/pet/applicationservice/controller/ApplicationController.java
+++ b/src/main/java/hello/pet/applicationservice/controller/ApplicationController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -101,5 +102,19 @@ public class ApplicationController {
 
         boolean hasApplied = applicationService.hasUserAppliedToAnnouncement(announcementId, userId);
         return ResponseEntity.status(HttpStatus.OK).body(hasApplied);
+    }
+
+    /**
+     * 공고 마감 시 해당 공고의 모든 신청 상태를 UNDER_REVIEW로 변경
+     * announcement-service의 스케줄러에서 호출됨
+     *
+     * @param announcementId 마감된 공고 ID
+     */
+    @PutMapping("/announcement/{announcementId}/close")
+    public ResponseEntity<Void> updateApplicationsToUnderReviewForClosedAnnouncement(
+            @PathVariable Long announcementId) {
+
+        applicationService.updateApplicationsToUnderReviewForClosedAnnouncement(announcementId);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/hello/pet/applicationservice/dto/response/AnnouncementResponse.java
+++ b/src/main/java/hello/pet/applicationservice/dto/response/AnnouncementResponse.java
@@ -1,5 +1,6 @@
 package hello.pet.applicationservice.dto.response;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -19,7 +20,7 @@ public class AnnouncementResponse {
     private int age;
     private String shelterName;
     private LocalDateTime createdAt;
-    private LocalDateTime endDate;
+    private LocalDate endDate;
     private String imageUrl;
     private String announcementStatus;
     private String animalType;

--- a/src/main/java/hello/pet/applicationservice/repository/ApplicationRepository.java
+++ b/src/main/java/hello/pet/applicationservice/repository/ApplicationRepository.java
@@ -2,6 +2,7 @@ package hello.pet.applicationservice.repository;
 
 import hello.pet.applicationservice.entity.Application;
 import hello.pet.applicationservice.entity.ApplicationStatus;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -35,4 +36,7 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
                                                              ApplicationStatus status);
 
     Optional<Application> findByUserIdAndAnnouncementId(Long userId, Long announcementId);
+
+    // 특정 공고의 특정 상태 신청서들 조회
+    List<Application> findByAnnouncementIdAndStatus(Long announcementId, ApplicationStatus status);
 }

--- a/src/main/java/hello/pet/applicationservice/service/ApplicationService.java
+++ b/src/main/java/hello/pet/applicationservice/service/ApplicationService.java
@@ -24,11 +24,13 @@ import jakarta.persistence.EntityNotFoundException;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -173,5 +175,35 @@ public class ApplicationService {
     @Transactional(readOnly = true)
     public boolean hasUserAppliedToAnnouncement(Long announcementId, Long userId) {
         return applicationRepository.findByUserIdAndAnnouncementId(userId, announcementId).isPresent();
+    }
+
+    /**
+     * 공고 마감 시 해당 공고의 모든 신청 상태를 UNDER_REVIEW로 변경
+     * announcement-service의 스케줄러에서 호출됨
+     *
+     * @param announcementId 마감된 공고 ID
+     */
+    public void updateApplicationsToUnderReviewForClosedAnnouncement(Long announcementId) {
+        log.info("공고 ID {}의 모든 신청을 UNDER_REVIEW 상태로 변경 시작", announcementId);
+
+        // 해당 공고의 모든 SUBMITTED 상태 신청서 조회
+        List<Application> pendingApplications =
+                applicationRepository.findByAnnouncementIdAndStatus(announcementId, ApplicationStatus.SUBMITTED);
+
+        if (pendingApplications.isEmpty()) {
+            log.info("공고 ID {}에 대기 중인 신청이 없습니다.", announcementId);
+            return;
+        }
+
+        // 각 신청서의 상태를 UNDER_REVIEW로 변경
+        for (Application application : pendingApplications) {
+            application.changeStatus(ApplicationStatus.UNDER_REVIEW);
+            log.debug("신청 ID {} 상태를 UNDER_REVIEW로 변경", application.getId());
+        }
+
+        // 변경 사항 저장
+        applicationRepository.saveAll(pendingApplications);
+
+        log.info("공고 ID {}의 {} 건의 신청을 UNDER_REVIEW 상태로 변경 완료", announcementId, pendingApplications.size());
     }
 }


### PR DESCRIPTION
## 📌 작업 내용
<!-- 이번 PR에서 수정/추가된 핵심 내용을 간단히 작성하세요 -->
공고가 마감되면 해당 신청서의 상태를 일괄 변경하는 기능을 구현했습니다.

## 🔗 관련 이슈
Closes #17 

## ✅ PR 생성 전 체크리스트
- [x] 병합할 브랜치 확인
- [x] 코드 정상 동작 확인

## 💬 리뷰 메모
<!-- 리뷰어에게 강조하거나 논의할 부분을 작성하세요-->
